### PR TITLE
(GH-1) Add ability to reset the ScriptHost

### DIFF
--- a/src/Cake.Bridge/CakeBridge.cs
+++ b/src/Cake.Bridge/CakeBridge.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Cake.Bridge;
 using Cake.Core;
@@ -12,7 +13,9 @@ using Cake.Core.Configuration;
 // ReSharper disable once CheckNamespace
 public static class CakeBridge
 {
-    public static IScriptHost ScriptHost { get; } = GetScriptHost();
+    private static IScriptHost _scriptHost = GetScriptHost();
+
+    public static IScriptHost ScriptHost => _scriptHost;
     public static ICakeContext Context => ScriptHost.Context;
     public static IReadOnlyList<ICakeTaskInfo> Tasks => ScriptHost.Tasks;
 
@@ -91,5 +94,13 @@ public static class CakeBridge
                 new CakeReportPrinter(console, context),
                 arguments
                 );
+    }
+
+    /// <summary>
+    /// Replaces the <see cref="ScriptHost"/> with a new one
+    /// </summary>
+    public static void ResetScriptHost()
+    {
+        Interlocked.Exchange(ref _scriptHost, GetScriptHost());
     }
 }


### PR DESCRIPTION
I took an initial stab at this one and ended up going back to my initial idea of having a method that allows the dev to reset the `ScriptHost`.

There are two scenarios I'm thinking:

**Scenario 1**: (Not covered by this PR) The host app is controlled by the Cake dev, and the app is aware that the code being run is a Cake script _and_ knows about Cake.Bridge, so it could potentially use something like `ExecuteScoped`, etc.

**Scenario 2**: (This PR) The host app is not controlled by the Cake dev, and the app is not aware that it's running a Cake script (all it knows is how to run C# code, and because it's referencing Cake.Bridge, everything magically works).

The goal in both scenarios is the same: Run a Cake script multiple times in the same process. Example of a Cake Script that would work after this PR:

build.cake:

```
var target = Context.Argument("target", "Test");
var configuration = Context.Argument("configuration", "Release");

Task("Test")
    .Does(() =>
    {
        Context.Information($"Hello from App Host ({configuration})");
    });

RunTarget(target);

#if MYCAKEHOST
ResetScriptHost();
#endif
```

We expect that the host app defines a constant `MYCAKEHOST` which tells us that CakeBridge is loaded and therefore we can call this method, otherwise running the `.cake` script normally via `dotnet cake` and other runners would just ignore this instruction.

Let me know what you think.

This seemed the cleanest way to call into `Cake.Bridge` whilst still being able to run the same code via Cake, and without changing the original Cake script code too much.

---

Closes #1 